### PR TITLE
Fix flyway migration goal error

### DIFF
--- a/cms/Makefile
+++ b/cms/Makefile
@@ -3,7 +3,7 @@
 infra-start:
 	docker compose -f docker-compose.yml up -d
 	./scripts/bin/waitForDB.sh
-	./mvnw -pl . flyway:migration
+	./mvnw -pl . flyway:migrate
 
 infra-cleanup:
 	docker compose -f docker-compose.yml down


### PR DESCRIPTION
Fix `make infra-restart` by correcting the Flyway Maven goal from `migration` to `migrate`.