### PR TITLE
Fix invalid bean definition error

### DIFF
--- a/cms/auth-service/src/main/java/org/max/cms/auth/config/AuthConfig.java
+++ b/cms/auth-service/src/main/java/org/max/cms/auth/config/AuthConfig.java
@@ -1,13 +1,9 @@
 package org.max.cms.auth.config;
 
-import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @Configuration
 @ComponentScan(basePackages = "org.max.cms.auth")
-@EntityScan(basePackages = "org.max.cms.auth.entity")
-@EnableJpaRepositories(basePackages = "org.max.cms.auth.repository")
 public class AuthConfig {
 }

--- a/cms/bootloader/src/main/java/org/max/cms/Application.java
+++ b/cms/bootloader/src/main/java/org/max/cms/Application.java
@@ -2,9 +2,7 @@ package org.max.cms;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.context.annotation.ComponentScan;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication
 @ComponentScan(basePackages = {
@@ -12,18 +10,6 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
     "org.max.cms.auth", 
     "org.max.cms.user",
     "org.max.cms.asset"
-})
-@EntityScan(basePackages = {
-    "org.max.cms.common.entity",
-    "org.max.cms.auth.entity",
-    "org.max.cms.user.entity", 
-    "org.max.cms.asset.entity"
-})
-@EnableJpaRepositories(basePackages = {
-    "org.max.cms.common.repository",
-    "org.max.cms.auth.repository",
-    "org.max.cms.user.repository",
-    "org.max.cms.asset.repository"
 })
 public class Application {
 

--- a/cms/bootloader/src/main/resources/application.yml
+++ b/cms/bootloader/src/main/resources/application.yml
@@ -4,6 +4,10 @@ spring:
   profiles:
     active: dev
   
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
+  
   datasource:
     driver-class-name: org.postgresql.Driver
     url: jdbc:postgresql://localhost:5432/minicms
@@ -15,15 +19,6 @@ spring:
       connection-timeout: 30000
       idle-timeout: 600000
       max-lifetime: 1800000
-  
-  jpa:
-    hibernate:
-      ddl-auto: none
-    show-sql: false
-    properties:
-      hibernate:
-        dialect: org.hibernate.dialect.PostgreSQLDialect
-        format_sql: true
   
   flyway:
     enabled: true

--- a/cms/common-service/src/main/java/org/max/cms/common/config/CommonConfig.java
+++ b/cms/common-service/src/main/java/org/max/cms/common/config/CommonConfig.java
@@ -1,13 +1,9 @@
 package org.max.cms.common.config;
 
-import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @Configuration
 @ComponentScan(basePackages = "org.max.cms.common")
-@EntityScan(basePackages = "org.max.cms.common.entity")
-@EnableJpaRepositories(basePackages = "org.max.cms.common.repository")
 public class CommonConfig {
 }


### PR DESCRIPTION
Remove conflicting JPA configurations to resolve `BeanDefinitionStoreException` when using MyBatis Plus.

The application is designed to use MyBatis Plus for data access. However, the presence of JPA-related annotations (`@EnableJpaRepositories`, `@EntityScan`) and configuration in `application.yml` caused Spring Boot to attempt to create JPA proxies for MyBatis mappers, leading to an `Invalid value type for attribute 'factoryBeanObjectType'` error during application startup. This PR removes the unnecessary JPA configurations.