### PR TITLE
修复cms项目以便本地启动

### DIFF
--- a/cms/asset-service/pom.xml
+++ b/cms/asset-service/pom.xml
@@ -45,7 +45,7 @@
         </dependency>
         <dependency>
             <groupId>com.baomidou</groupId>
-            <artifactId>mybatis-plus-boot-starter</artifactId>
+            <artifactId>mybatis-plus-spring-boot3-starter</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/cms/auth-service/pom.xml
+++ b/cms/auth-service/pom.xml
@@ -64,7 +64,7 @@
         </dependency>
         <dependency>
             <groupId>com.baomidou</groupId>
-            <artifactId>mybatis-plus-boot-starter</artifactId>
+            <artifactId>mybatis-plus-spring-boot3-starter</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/cms/bootloader/pom.xml
+++ b/cms/bootloader/pom.xml
@@ -37,10 +37,7 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-jpa</artifactId>
-        </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
@@ -65,7 +62,11 @@
         </dependency>
         <dependency>
             <groupId>com.baomidou</groupId>
-            <artifactId>mybatis-plus-boot-starter</artifactId>
+            <artifactId>mybatis-plus-spring-boot3-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.baomidou</groupId>
+            <artifactId>mybatis-plus-jsqlparser</artifactId>
         </dependency>
         
         <!-- Migration -->
@@ -85,6 +86,7 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <configuration>
+                    <skip>false</skip>
                     <excludes>
                         <exclude>
                             <groupId>org.projectlombok</groupId>

--- a/cms/bootloader/src/main/resources/application.yml
+++ b/cms/bootloader/src/main/resources/application.yml
@@ -7,6 +7,7 @@ spring:
   autoconfigure:
     exclude:
       - org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
+      - org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration
   
   datasource:
     driver-class-name: org.postgresql.Driver
@@ -22,7 +23,7 @@ spring:
   
   flyway:
     enabled: true
-    locations: filesystem:scripts/db/migration
+    locations: filesystem:../scripts/db/migration
     baseline-on-migrate: true
     baseline-version: 0
     

--- a/cms/common-service/pom.xml
+++ b/cms/common-service/pom.xml
@@ -19,10 +19,7 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-jpa</artifactId>
-        </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
@@ -39,7 +36,11 @@
         </dependency>
         <dependency>
             <groupId>com.baomidou</groupId>
-            <artifactId>mybatis-plus-boot-starter</artifactId>
+            <artifactId>mybatis-plus-spring-boot3-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.baomidou</groupId>
+            <artifactId>mybatis-plus-jsqlparser</artifactId>
         </dependency>
         
         <!-- Migration -->

--- a/cms/pom.xml
+++ b/cms/pom.xml
@@ -24,12 +24,13 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		
 		<!-- Version Management -->
-		<mybatis-plus.version>3.5.5</mybatis-plus.version>
+		<mybatis-plus.version>3.5.12</mybatis-plus.version>
 		<flyway.version>10.17.0</flyway.version>
 		<postgresql.version>42.7.3</postgresql.version>
 		<swagger.version>2.2.0</swagger.version>
 		<lombok.version>1.18.30</lombok.version>
 		<commons-lang3.version>3.14.0</commons-lang3.version>
+		<mybatis-plus-jsqlparser.version>3.5.12</mybatis-plus-jsqlparser.version>
 	</properties>
 	
 	<modules>
@@ -72,8 +73,13 @@
 			</dependency>
 			<dependency>
 				<groupId>com.baomidou</groupId>
-				<artifactId>mybatis-plus-boot-starter</artifactId>
+				<artifactId>mybatis-plus-spring-boot3-starter</artifactId>
 				<version>${mybatis-plus.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.baomidou</groupId>
+				<artifactId>mybatis-plus-jsqlparser</artifactId>
+				<version>${mybatis-plus-jsqlparser.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.flywaydb</groupId>
@@ -127,12 +133,7 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 				<configuration>
-					<excludes>
-						<exclude>
-							<groupId>org.projectlombok</groupId>
-							<artifactId>lombok</artifactId>
-						</exclude>
-					</excludes>
+					<skip>true</skip>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/cms/user-service/pom.xml
+++ b/cms/user-service/pom.xml
@@ -49,7 +49,7 @@
         </dependency>
         <dependency>
             <groupId>com.baomidou</groupId>
-            <artifactId>mybatis-plus-boot-starter</artifactId>
+            <artifactId>mybatis-plus-spring-boot3-starter</artifactId>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Fix CMS project startup by correcting Maven build, updating MyBatis-Plus compatibility, and resolving JPA conflicts.

The project failed to start due to a combination of issues: incorrect Spring Boot Maven plugin configuration applying repackaging to library modules, incompatible MyBatis-Plus version with Spring Boot 3, an incorrect Flyway migration path, and residual JPA dependencies conflicting with MyBatis-Plus. This PR addresses all these issues to enable local startup.