### PR TITLE
Fix unauthorized access on login API

### DIFF
--- a/cms/auth-service/src/main/java/org/max/cms/auth/controller/AuthController.java
+++ b/cms/auth-service/src/main/java/org/max/cms/auth/controller/AuthController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.*;
 import jakarta.validation.Valid;
 
 @RestController
-@RequestMapping("/api/auth")
+@RequestMapping("/auth")
 @RequiredArgsConstructor
 @CrossOrigin(origins = "*")
 public class AuthController {


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Correct `AuthController` path mapping to resolve 401 error on login.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `application.yml` defines a `context-path: /api`. The `AuthController` was incorrectly mapped with `@RequestMapping("/api/auth")`, leading to an effective endpoint of `/api/api/auth/login`. This caused `POST /api/auth/login` requests to fail with a 404 (which then resulted in a 401 Unauthorized response), despite Spring Security correctly excluding the path from JWT authentication. The fix aligns the controller path with the expected endpoint.