### PR TITLE
Fix database update type mismatch

### DIFF
--- a/cms/bootloader/src/main/resources/application.yml
+++ b/cms/bootloader/src/main/resources/application.yml
@@ -35,8 +35,8 @@ mybatis-plus:
   global-config:
     db-config:
       logic-delete-field: deleted
-      logic-delete-value: 1
-      logic-not-delete-value: 0
+      logic-delete-value: true
+      logic-not-delete-value: false
   mapper-locations: classpath:mapper/*.xml
 
 # Swagger Configuration


### PR DESCRIPTION
Update MyBatis-Plus logical delete values to boolean to resolve PostgreSQL type mismatch error.

The `deleted` field in `BaseEntity.java` is a `Boolean`, but MyBatis-Plus was configured to use integer values (0 and 1) for logical deletion. This caused a `PSQLException` when PostgreSQL tried to compare a boolean column with an integer value in `UPDATE` queries.