### PR TITLE
Update JWT key size for security

### DIFF
--- a/cms/auth-service/src/main/java/org/max/cms/auth/util/JwtUtil.java
+++ b/cms/auth-service/src/main/java/org/max/cms/auth/util/JwtUtil.java
@@ -18,13 +18,18 @@ import java.util.ArrayList;
 @Component
 public class JwtUtil {
 
-    @Value("${jwt.secret:mySecretKey}")
+    @Value("${jwt.secret:}")
     private String secret;
 
     @Value("${jwt.expiration:86400000}") // 24小时
     private Long expiration;
 
     private SecretKey getSigningKey() {
+        // Check if the secret is empty or too short (less than 256 bits / 32 bytes)
+        if (secret == null || secret.trim().isEmpty() || secret.getBytes().length < 32) {
+            // Generate a secure key automatically as recommended by JWT specification
+            return Keys.secretKeyFor(SignatureAlgorithm.HS256);
+        }
         return Keys.hmacShaKeyFor(secret.getBytes());
     }
 


### PR DESCRIPTION
Ensure JWT secret key meets security requirements by generating a secure key if the configured secret is too short.

The previous default secret was only 88 bits, which violates RFC 7518, Section 3.2, requiring HMAC-SHA keys to be at least 256 bits. This change automatically generates a secure key when the configured secret is insufficient.