### PR TITLE
Fix HttpClient provider issue

### DIFF
--- a/frontend/src/app/app.config.ts
+++ b/frontend/src/app/app.config.ts
@@ -1,5 +1,6 @@
 import { ApplicationConfig, provideBrowserGlobalErrorListeners, provideZonelessChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
+import { provideHttpClient, withFetch } from '@angular/common/http';
 
 import { routes } from './app.routes';
 import { provideClientHydration, withEventReplay } from '@angular/platform-browser';
@@ -8,7 +9,8 @@ export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
     provideZonelessChangeDetection(),
-    provideRouter(routes), 
+    provideRouter(routes),
+    provideHttpClient(withFetch()),
     provideClientHydration(withEventReplay())
   ]
 };


### PR DESCRIPTION
Add `provideHttpClient` to `app.config.ts` to resolve `NullInjectorError: No provider for _HttpClient!`.

The `NullInjectorError: No provider for _HttpClient!` occurred because `HttpClient` was being injected into `AuthService` but was not configured as a provider in the standalone Angular application. Adding `provideHttpClient()` makes `HttpClient` available for injection. `withFetch()` was also included for improved Server-Side Rendering performance.